### PR TITLE
fix: 调整播放和暂停图标

### DIFF
--- a/src/components/bottom-panel/BottomPanel.vue
+++ b/src/components/bottom-panel/BottomPanel.vue
@@ -37,10 +37,10 @@ function toggleVideoPlay() {
       <div class="flex items-center gap-2">
         <button class="btn-control"><IconPrev /></button>
         <button class="btn-control" v-if="playStatus" @click="toggleVideoPlay">
-          <IconPlay />
+          <IconPause />
         </button>
         <button class="btn-control" v-else @click="toggleVideoPlay">
-          <IconPause />
+          <IconPlay />
         </button>
         <button class="btn-control"><IconNext /></button>
         <span>00:00:00 / 00:00:00</span>


### PR DESCRIPTION
This pull request includes a change to the `toggleVideoPlay` function in the `BottomPanel.vue` file. The change swaps the `IconPlay` and `IconPause` button icons, so that when the video is playing, the button shows the `IconPause` to indicate that clicking it will pause the video, and vice versa when the video is paused.