### PR TITLE
chore: add thumbnails for video

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     ]
   },
   "dependencies": {
+    "@webav/av-cliper": "^0.4.1",
     "daisyui": "^4.8.0",
     "fabric": "^5.3.0",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@webav/av-cliper':
+    specifier: ^0.4.1
+    version: 0.4.1
   daisyui:
     specifier: ^4.8.0
     version: 4.8.0(postcss@8.4.36)
@@ -1121,6 +1124,10 @@ packages:
     resolution: {integrity: sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==}
     dev: true
 
+  /@types/dom-webcodecs@0.1.11:
+    resolution: {integrity: sha512-yPEZ3z7EohrmOxbk/QTAa0yonMFkNkjnVXqbGb7D4rMr+F1dGQ8ZUFxXkyLLJuiICPejZ0AZE9Rrk9wUCczx4A==}
+    dev: false
+
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
@@ -1601,6 +1608,19 @@ packages:
   /@vue/tsconfig@0.5.1:
     resolution: {integrity: sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==}
     dev: true
+
+  /@webav/av-cliper@0.4.1:
+    resolution: {integrity: sha512-n4zX0aswRuKHUQO4/2wNTxXqJEwWcWq/10UqPlUv5UuakVZ/lSomhbzrhQ21CXUSBoXnNv+H9vtKu5ipZqpzuQ==}
+    dependencies:
+      '@types/dom-webcodecs': 0.1.11
+      '@webav/mp4box.js': 0.5.3-fenghen
+      opfs-tools: 0.3.1
+      wave-resampler: 1.0.0
+    dev: false
+
+  /@webav/mp4box.js@0.5.3-fenghen:
+    resolution: {integrity: sha512-jAN15I3Po1Z6Ns02iknb6KGbird9rd1h9TGldzbwsar+88ZlHd+oVjOQnFavBdNDc5vmULUnldcWGDdKc02npw==}
+    dev: false
 
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -3134,6 +3154,7 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    requiresBuild: true
 
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3246,6 +3267,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    requiresBuild: true
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -3481,12 +3503,14 @@ packages:
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    requiresBuild: true
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    requiresBuild: true
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
@@ -4324,6 +4348,10 @@ packages:
       is-wsl: 3.1.0
     dev: true
 
+  /opfs-tools@0.3.1:
+    resolution: {integrity: sha512-4zLxeAqAKqZWMd8fVe4nfbqQL1oC5NRwhbRc1ugxFYmd93QxigUhSY/ockVTP1PThf0DFJEV+/co20cEm4KB/A==}
+    dev: false
+
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -4399,6 +4427,7 @@ packages:
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
 
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -5797,6 +5826,11 @@ packages:
       - debug
     dev: true
 
+  /wave-resampler@1.0.0:
+    resolution: {integrity: sha512-bE3rbpZXuKAV52Cd8/BeJvy82ZqEHK8pPWHrZ9JioaVVTBlmWbDC+u4p9blhFcf0Skepb4hlOAHc25XfqLC48g==}
+    engines: {node: '>=8'}
+    dev: false
+
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     requiresBuild: true
@@ -5935,6 +5969,7 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    requiresBuild: true
 
   /ws@8.16.0:
     resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}

--- a/src/components/bottom-panel/TrackList.vue
+++ b/src/components/bottom-panel/TrackList.vue
@@ -1,8 +1,26 @@
 <script setup lang="ts">
 import IconMusic from '~/assets/icons/icon-music.svg?component'
 import IconText from '~/assets/icons/icon-text.svg?component'
-import IconVideo from '~/assets/icons/icon-video.svg?component'
+import movie from '/bird.mp4'
+import { MP4Clip } from '@WebAV/av-cliper'
+import { watchEffect, ref } from 'vue'
+type Thumbnail = {
+  img: string
+  ts: number
+};
+const thumbnails = ref<Thumbnail[]>([])
+watchEffect(async () => {
+  // const clip = new MP4Clip((await fetch('https://assets.fedtop.com/picbed/movie.mp4')).body!)
+  const clip = new MP4Clip((await fetch(movie)).body!)
+  await clip.ready
+  // keyframe thumbnails
+  thumbnails.value = (await clip.thumbnails()).map(it => ({
+    img: URL.createObjectURL(it.img),
+    ts: it.ts
+  }))
+})
 </script>
+
 <template>
   <div class="grid content-center flex-1 text-center">
     <div class="element-track">
@@ -12,9 +30,10 @@ import IconVideo from '~/assets/icons/icon-video.svg?component'
       </div>
     </div>
     <div class="video-track">
-      <div class="flex gap-2">
-        <IconVideo />
-        <span>+ 视频轨道</span>
+      <div class="flex overflow-auto">
+        <div class="flex-none" v-for="img in thumbnails" :key="img.ts">
+          <img :src="img.img" :title="(img.ts / 1e6).toFixed(2) + 's'" />
+        </div>
       </div>
     </div>
     <div class="music-track">
@@ -25,6 +44,7 @@ import IconVideo from '~/assets/icons/icon-video.svg?component'
     </div>
   </div>
 </template>
+
 <style lang="scss" scoped>
 .music-track,
 .video-track,
@@ -46,7 +66,7 @@ import IconVideo from '~/assets/icons/icon-video.svg?component'
   // align-content: center;
   transition: width 200ms ease-out 0s;
   position: relative;
-  height: 48px;
+  height: 75px;
   background: rgb(30, 30, 41);
 }
 .music-track {


### PR DESCRIPTION
This pull request primarily introduces the usage of the `@webav/av-cliper` library in the project, and makes several changes to the `pnpm-lock.yaml` and `package.json` files. The most significant changes include adding `@webav/av-cliper` to the dependencies, updating the `pnpm-lock.yaml` file to reflect this new dependency and its sub-dependencies, and modifying the `TrackList.vue` component to use the `MP4Clip` class from `@webav/av-cliper`.

New dependencies:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R29): Added `@webav/av-cliper` to the list of dependencies.

Updates to `pnpm-lock.yaml`:

* [`settings:`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8-R10): Added `@webav/av-cliper` to the list of dependencies.
* [`packages:`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1127-R1130): Added several new packages related to `@webav/av-cliper`, including `@types/dom-webcodecs`, `@webav/av-cliper`, `@webav/mp4box.js`, `opfs-tools`, and `wave-resampler`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1127-R1130) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1612-R1624) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4351-R4354) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5829-R5833)
* [`packages:`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3157): Added `requiresBuild: true` to several packages, including `fs.realpath`, `glob`, `inflight`, `inherits`, `path-is-absolute`, and `wrappy`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3157) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3270) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3506-R3513) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4430) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5972)

Changes to `TrackList.vue`:

* Imported `MP4Clip` from `@webav/av-cliper` and made use of it to generate thumbnails for a video clip.
* Replaced the `+ 视频轨道` text and `IconVideo` with a list of thumbnails generated from the video clip.
* Increased the height of the `.video-track` class from `48px` to `75px`.

Preview:
![image](https://github.com/wangrongding/WebCut/assets/68503578/13bb7dbc-efae-4b12-b3e7-ea188535f065)
