### PR TITLE
feat: add currentTime and duration to playerStore

### DIFF
--- a/src/components/bottom-panel/BottomPanel.vue
+++ b/src/components/bottom-panel/BottomPanel.vue
@@ -14,10 +14,11 @@ import IconZoomin from '~/assets/icons/control-zoomin.svg?component'
 import IconZoomout from '~/assets/icons/control-zoomout.svg?component'
 import IconZoomToFit from '~/assets/icons/control-zoomtofit.svg?component'
 import { usePlayerStore } from '~/stores/player'
+import { formatSeconds } from '~/utils/index'
 
 const playerStore = usePlayerStore()
 // 将 store 中的 playStatus 转换为 ref
-const { playStatus } = storeToRefs(playerStore)
+const { playStatus, currentTime, duration } = storeToRefs(playerStore)
 
 function toggleVideoPlay() {
   playerStore.playStatus = !playStatus.value
@@ -43,7 +44,7 @@ function toggleVideoPlay() {
           <IconPlay />
         </button>
         <button class="btn-control"><IconNext /></button>
-        <span>00:00:00 / 00:00:00</span>
+        <span>{{ `${formatSeconds(currentTime)} / ${formatSeconds(duration)}`}}</span>
       </div>
       <div class="flex gap-4">
         <button class="tooltip btn-control" data-tip="放大"><IconZoomout /></button>

--- a/src/components/player/CanvasPlayer.vue
+++ b/src/components/player/CanvasPlayer.vue
@@ -14,7 +14,7 @@ defineProps<{
 const container = ref<HTMLElement | null>(null)
 let video: HTMLVideoElement
 const playerStore = usePlayerStore()
-const { playStatus } = storeToRefs(playerStore)
+const { playStatus, currentTime, duration } = storeToRefs(playerStore)
 const menuShow = ref(false)
 const contextMenuPosition = ref({ x: 0, y: 0 })
 const contextMenu = ref<typeof ContextMenu | null>(null)
@@ -140,10 +140,12 @@ function drawVideo() {
       originX: 'left',
       originY: 'top'
     })
+    duration.value = video.duration
     canvas.add(videoElement)
     canvas.setActiveObject(videoElement)
     continuouslyRepaint()
   })
+  video.addEventListener('timeupdate', () => { currentTime.value = video.currentTime })
 }
 
 // 持续重绘

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -13,5 +13,9 @@ export const usePlayerStore = defineStore('playerStore', () => {
   // 轨道数
   const trackCount = computed(() => playList.value.length)
 
-  return { playStatus, togglePlay, playList, trackCount }
+  const currentTime = ref<number>(0)
+
+  const duration = ref<number>(0)
+
+  return { playStatus, togglePlay, playList, trackCount, currentTime, duration }
 })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,13 @@
+export function formatSeconds(seconds: number) {
+  seconds = Math.floor(seconds)
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const remainingSeconds = seconds % 60
+
+  const formattedTime = `${padZero(hours)}:${padZero(minutes)}:${padZero(remainingSeconds)}`
+  return formattedTime
+}
+
+export function padZero(number: number) {
+  return number.toString().padStart(2, '0')
+}


### PR DESCRIPTION
This pull request primarily focuses on improving the video playback functionality in the application. The changes involve the addition of a `currentTime` and `duration` state to the player store, the creation of a utility function to format seconds into a time string, and the utilization of these new features in the `BottomPanel.vue` and `CanvasPlayer.vue` components.

Additions to player store state:

* [`src/stores/player.ts`](diffhunk://#diff-39e7d9871c160cae18f3b7642f30a881beb9c638d2204595dcedb0c6055f7766L16-R20): Added `currentTime` and `duration` as reactive state variables in the player store. These variables will keep track of the current playback time and total duration of the video, respectively.

Utility function creation:

* [`src/utils/index.ts`](diffhunk://#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99R1-R13): Created a `formatSeconds` function that takes a number of seconds and formats it into a time string in the format of hours, minutes, and seconds. This function will be used to display the current time and duration in the player.

Updates to Vue components:

* [`src/components/bottom-panel/BottomPanel.vue`](diffhunk://#diff-b38b427c5343b57d146d0452343273b37f0b0cf3d280363e208a267d3ae64c72R17-R21): Imported the `formatSeconds` function and added `currentTime` and `duration` to the list of variables obtained from the player store. Updated the time display in the bottom panel to use these new variables. [[1]](diffhunk://#diff-b38b427c5343b57d146d0452343273b37f0b0cf3d280363e208a267d3ae64c72R17-R21) [[2]](diffhunk://#diff-b38b427c5343b57d146d0452343273b37f0b0cf3d280363e208a267d3ae64c72L46-R47)
* [`src/components/player/CanvasPlayer.vue`](diffhunk://#diff-60478180f811a96381b828edeeef471053421d20f9ac4bda2aedc89daebb3595L17-R17): Similar to `BottomPanel.vue`, added `currentTime` and `duration` to the list of variables obtained from the player store. Also added event listeners to the video element to update `currentTime` and `duration` accordingly as the video plays. [[1]](diffhunk://#diff-60478180f811a96381b828edeeef471053421d20f9ac4bda2aedc89daebb3595L17-R17) [[2]](diffhunk://#diff-60478180f811a96381b828edeeef471053421d20f9ac4bda2aedc89daebb3595R143-R148)

Test:
![Animation](https://github.com/wangrongding/WebCut/assets/68503578/fe2abe90-2e96-4f3c-925c-abdca2d37a22)
